### PR TITLE
Update PackageDownload to open files as binary

### DIFF
--- a/simplepypi/bin/simplepypi
+++ b/simplepypi/bin/simplepypi
@@ -197,7 +197,7 @@ class PackageDownload(RequestHandler):
                 )
             )
 
-        with open(path, 'r') as fd:
+        with open(path, 'rb') as fd:
             while True:
                 chunk = fd.read(1024**2)
 


### PR DESCRIPTION
This change provides compatibility with Python 3, which no longer ignores encoding errors. Attempting to download from the hosted repository would fail without this.